### PR TITLE
v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.release.tag_name }}
+
       - name: Set release version number
         run: sed -i -e "s/latest/${{ github.event.release.tag_name }}/g" docker-compose.dev.yml
+
       - name: Build Image
-        run: docker compose -f docker-compose.dev.yml build
+        run: |
+          cp .env.example .env
+          docker compose -f docker-compose.dev.yml build
+
       - name: Push Image to Docker Hub
         run: docker compose -f docker-compose.dev.yml push
 
@@ -60,7 +65,9 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Build Image
-        run: docker compose -f docker-compose.dev.yml build
+        run: |
+          cp .env.example .env
+          docker compose -f docker-compose.dev.yml build
 
       - name: Push Image to Docker Hub
         run: docker compose -f docker-compose.dev.yml push

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hili-lipsum",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hili-lipsum",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hili-lipsum",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Non-sensical hilichurlian sentence generator.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
- Fix: bump version to 2.1.0. Follow-up for PR [v2.1.0-alpha.1](https://github.com/weaponsforge/hili-lipsum/pull/27)
- Fix: create a temporary .env file on Docker build